### PR TITLE
feat: enforce egress secret references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf stubs
-        run: buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+        run: |
+          buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+          buf generate buf.build/agynio/api --path agynio/api/egress/v1
 
       - name: Go build
         run: go build ./...

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -25,7 +25,9 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf stubs
-        run: buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+        run: |
+          buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+          buf generate buf.build/agynio/api --path agynio/api/egress/v1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -86,7 +88,9 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf stubs
-        run: buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+        run: |
+          buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+          buf generate buf.build/agynio/api --path agynio/api/egress/v1
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,9 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf stubs
-        run: buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+        run: |
+          buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+          buf generate buf.build/agynio/api --path agynio/api/egress/v1
 
       - name: Build and push secrets image
         uses: docker/build-push-action@v6

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ all: build
 
 proto:
 	buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+	buf generate buf.build/agynio/api --path agynio/api/egress/v1
 
 build:
 	GOFLAGS=-mod=mod go build ./...

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Proto stubs are generated via Buf and are gitignored under `gen/go`.
 
 ```bash
 buf generate buf.build/agynio/api --path agynio/api/secrets/v1
+buf generate buf.build/agynio/api --path agynio/api/egress/v1
 go build ./...
 ```
 
@@ -30,6 +31,8 @@ go run ./cmd/secrets
 | --- | --- | --- | --- |
 | `DATABASE_URL` | Yes | - | PostgreSQL connection string. |
 | `GRPC_ADDRESS` | No | `:50051` | Address for the gRPC server to listen on. |
+| `ENCRYPTION_KEY_FILE` | Yes | - | Path to the encryption key file used for local secret values. |
+| `EGRESS_RULES_GRPC_TARGET` | No | - | EgressRules gRPC target used to fail-closed on `DeleteSecret` when egress rules reference a secret. |
 
 ## Repository Layout
 

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,9 +6,11 @@ plugins:
     opt:
       - paths=source_relative
       - Magynio/api/secrets/v1/secrets.proto=github.com/agynio/secrets/gen/go/agynio/api/secrets/v1
+      - Magynio/api/egress/v1/egress.proto=github.com/agynio/secrets/gen/go/agynio/api/egress/v1
   - plugin: buf.build/grpc/go
     out: gen/go
     opt:
       - paths=source_relative
       - require_unimplemented_servers=false
       - Magynio/api/secrets/v1/secrets.proto=github.com/agynio/secrets/gen/go/agynio/api/secrets/v1
+      - Magynio/api/egress/v1/egress.proto=github.com/agynio/secrets/gen/go/agynio/api/egress/v1

--- a/charts/secrets/templates/deployment.yaml
+++ b/charts/secrets/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
               {{- else }}
               value: {{ required "database.url or database.existingSecret.name must be set" $url | quote }}
               {{- end }}
+            {{- with .Values.egressRules.grpcTarget }}
+            - name: EGRESS_RULES_GRPC_TARGET
+              value: {{ . | quote }}
+            {{- end }}
 {{- include "secrets.encryptionKeyEnv" . | nindent 12 }}
           livenessProbe:
             tcpSocket:

--- a/charts/secrets/values.yaml
+++ b/charts/secrets/values.yaml
@@ -48,6 +48,9 @@ secrets:
   encryptionKeyFile: ""
   encryptionKeySecretName: "secrets-encryption-key"
 
+egressRules:
+  grpcTarget: ""
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/cmd/secrets/main.go
+++ b/cmd/secrets/main.go
@@ -58,7 +58,16 @@ func run() error {
 	}
 
 	grpcServer := grpc.NewServer()
-	secretsv1.RegisterSecretsServiceServer(grpcServer, server.New(store.NewStore(pool), vault.NewClient(http.DefaultClient), encryptionKey))
+	secretsServer := server.New(store.NewStore(pool), vault.NewClient(http.DefaultClient), encryptionKey)
+	egressRulesClient, egressRulesConn, err := server.DialEgressRulesClient(ctx, cfg.EgressRulesGRPCTarget)
+	if err != nil {
+		return err
+	}
+	if egressRulesConn != nil {
+		defer egressRulesConn.Close()
+	}
+	secretsServer.WithEgressRulesClient(egressRulesClient)
+	secretsv1.RegisterSecretsServiceServer(grpcServer, secretsServer)
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Config struct {
-	GRPCAddress       string
-	DatabaseURL       string
-	EncryptionKeyFile string
+	GRPCAddress           string
+	DatabaseURL           string
+	EncryptionKeyFile     string
+	EgressRulesGRPCTarget string
 }
 
 func FromEnv() (Config, error) {
@@ -25,5 +26,6 @@ func FromEnv() (Config, error) {
 	if cfg.EncryptionKeyFile == "" {
 		return Config{}, fmt.Errorf("ENCRYPTION_KEY_FILE must be set")
 	}
+	cfg.EgressRulesGRPCTarget = os.Getenv("EGRESS_RULES_GRPC_TARGET")
 	return cfg, nil
 }

--- a/internal/server/egress_rules.go
+++ b/internal/server/egress_rules.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	egressv1 "github.com/agynio/secrets/gen/go/agynio/api/egress/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type EgressRulesClient interface {
+	CountRulesReferencingSecret(ctx context.Context, secretID string) (EgressSecretReferences, error)
+}
+
+type EgressSecretReferences struct {
+	Count         int32
+	EgressRuleIDs []string
+}
+
+type egressRulesGRPCClient struct {
+	client egressv1.EgressRulesServiceClient
+}
+
+func NewEgressRulesGRPCClient(conn grpc.ClientConnInterface) EgressRulesClient {
+	return egressRulesGRPCClient{client: egressv1.NewEgressRulesServiceClient(conn)}
+}
+
+func DialEgressRulesClient(ctx context.Context, target string) (EgressRulesClient, *grpc.ClientConn, error) {
+	trimmedTarget := strings.TrimSpace(target)
+	if trimmedTarget == "" {
+		return nil, nil, nil
+	}
+	conn, err := grpc.NewClient(trimmedTarget, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("create egress rules grpc client: %w", err)
+	}
+	return NewEgressRulesGRPCClient(conn), conn, nil
+}
+
+func (c egressRulesGRPCClient) CountRulesReferencingSecret(ctx context.Context, secretID string) (EgressSecretReferences, error) {
+	resp, err := c.client.CountRulesReferencingSecret(ctx, &egressv1.CountRulesReferencingSecretRequest{SecretId: secretID})
+	if err != nil {
+		return EgressSecretReferences{}, err
+	}
+	return EgressSecretReferences{
+		Count:         resp.GetCount(),
+		EgressRuleIDs: resp.GetEgressRuleIds(),
+	}, nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -45,11 +46,17 @@ type Server struct {
 	secretsv1.UnimplementedSecretsServiceServer
 	store         SecretStore
 	vault         VaultResolver
+	egressRules   EgressRulesClient
 	encryptionKey []byte
 }
 
 func New(store SecretStore, vaultClient VaultResolver, encryptionKey []byte) *Server {
 	return &Server{store: store, vault: vaultClient, encryptionKey: encryptionKey}
+}
+
+func (s *Server) WithEgressRulesClient(client EgressRulesClient) *Server {
+	s.egressRules = client
+	return s
 }
 
 func (s *Server) CreateSecretProvider(ctx context.Context, req *secretsv1.CreateSecretProviderRequest) (*secretsv1.CreateSecretProviderResponse, error) {
@@ -300,10 +307,33 @@ func (s *Server) DeleteSecret(ctx context.Context, req *secretsv1.DeleteSecretRe
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
+	if err := s.ensureSecretNotReferencedByEgressRules(ctx, secretID); err != nil {
+		return nil, err
+	}
 	if err := s.store.DeleteSecret(ctx, secretID); err != nil {
 		return nil, toStatusError(err)
 	}
 	return &secretsv1.DeleteSecretResponse{}, nil
+}
+
+func (s *Server) ensureSecretNotReferencedByEgressRules(ctx context.Context, secretID uuid.UUID) error {
+	if s.egressRules == nil {
+		return status.Error(codes.FailedPrecondition, "cannot verify egress rule references for secret deletion")
+	}
+	references, err := s.egressRules.CountRulesReferencingSecret(ctx, secretID.String())
+	if err != nil {
+		return status.Errorf(codes.FailedPrecondition, "cannot verify egress rule references for secret deletion: %v", err)
+	}
+	if references.Count == 0 {
+		return nil
+	}
+	sort.Strings(references.EgressRuleIDs)
+	return status.Errorf(
+		codes.FailedPrecondition,
+		"secret is referenced by %d egress rule(s): %s",
+		references.Count,
+		strings.Join(references.EgressRuleIDs, ", "),
+	)
 }
 
 func (s *Server) ListSecrets(ctx context.Context, req *secretsv1.ListSecretsRequest) (*secretsv1.ListSecretsResponse, error) {
@@ -364,6 +394,24 @@ func (s *Server) ResolveSecret(ctx context.Context, req *secretsv1.ResolveSecret
 		return nil, mapVaultResolveError(err, "remote_name")
 	}
 	return &secretsv1.ResolveSecretResponse{Value: value}, nil
+}
+
+func (s *Server) ResolveSecretExists(ctx context.Context, req *secretsv1.ResolveSecretExistsRequest) (*secretsv1.ResolveSecretExistsResponse, error) {
+	secretID, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	secret, err := s.store.GetSecret(ctx, secretID)
+	if err != nil {
+		if errors.Is(err, store.ErrSecretNotFound) {
+			return &secretsv1.ResolveSecretExistsResponse{Exists: false}, nil
+		}
+		return nil, toStatusError(err)
+	}
+	return &secretsv1.ResolveSecretExistsResponse{
+		Exists:         true,
+		OrganizationId: secret.OrganizationID.String(),
+	}, nil
 }
 
 func (s *Server) CreateImagePullSecret(ctx context.Context, req *secretsv1.CreateImagePullSecretRequest) (*secretsv1.CreateImagePullSecretResponse, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	secretsv1 "github.com/agynio/secrets/gen/go/agynio/api/secrets/v1"
@@ -237,5 +239,187 @@ func TestParseRemoteSecretRef(t *testing.T) {
 	}
 	if ref.Reference != "kv/path/key" {
 		t.Fatalf("unexpected reference")
+	}
+}
+
+type fakeSecretStore struct {
+	getSecret       store.Secret
+	getSecretErr    error
+	deletedSecretID uuid.UUID
+}
+
+func (f fakeSecretStore) CreateSecretProvider(context.Context, store.CreateSecretProviderInput) (store.SecretProvider, error) {
+	panic("unexpected CreateSecretProvider")
+}
+
+func (f fakeSecretStore) GetSecretProvider(context.Context, uuid.UUID) (store.SecretProvider, error) {
+	panic("unexpected GetSecretProvider")
+}
+
+func (f fakeSecretStore) UpdateSecretProvider(context.Context, uuid.UUID, store.UpdateSecretProviderInput) (store.SecretProvider, error) {
+	panic("unexpected UpdateSecretProvider")
+}
+
+func (f fakeSecretStore) DeleteSecretProvider(context.Context, uuid.UUID) error {
+	panic("unexpected DeleteSecretProvider")
+}
+
+func (f fakeSecretStore) ListSecretProviders(context.Context, store.ListSecretProvidersParams) ([]store.SecretProvider, string, error) {
+	panic("unexpected ListSecretProviders")
+}
+
+func (f fakeSecretStore) CreateSecret(context.Context, store.CreateSecretInput) (store.Secret, error) {
+	panic("unexpected CreateSecret")
+}
+
+func (f fakeSecretStore) GetSecret(context.Context, uuid.UUID) (store.Secret, error) {
+	if f.getSecretErr != nil {
+		return store.Secret{}, f.getSecretErr
+	}
+	return f.getSecret, nil
+}
+
+func (f fakeSecretStore) UpdateSecret(context.Context, uuid.UUID, store.UpdateSecretInput) (store.Secret, error) {
+	panic("unexpected UpdateSecret")
+}
+
+func (f *fakeSecretStore) DeleteSecret(_ context.Context, id uuid.UUID) error {
+	f.deletedSecretID = id
+	return nil
+}
+
+func (f fakeSecretStore) ListSecrets(context.Context, store.ListSecretsParams) ([]store.Secret, string, error) {
+	panic("unexpected ListSecrets")
+}
+
+func (f fakeSecretStore) CreateImagePullSecret(context.Context, store.CreateImagePullSecretInput) (store.ImagePullSecret, error) {
+	panic("unexpected CreateImagePullSecret")
+}
+
+func (f fakeSecretStore) GetImagePullSecret(context.Context, uuid.UUID) (store.ImagePullSecret, error) {
+	panic("unexpected GetImagePullSecret")
+}
+
+func (f fakeSecretStore) UpdateImagePullSecret(context.Context, uuid.UUID, store.UpdateImagePullSecretInput) (store.ImagePullSecret, error) {
+	panic("unexpected UpdateImagePullSecret")
+}
+
+func (f fakeSecretStore) DeleteImagePullSecret(context.Context, uuid.UUID) error {
+	panic("unexpected DeleteImagePullSecret")
+}
+
+func (f fakeSecretStore) ListImagePullSecrets(context.Context, store.ListImagePullSecretsParams) ([]store.ImagePullSecret, string, error) {
+	panic("unexpected ListImagePullSecrets")
+}
+
+type fakeEgressRulesClient struct {
+	references EgressSecretReferences
+	err        error
+	secretID   string
+	called     bool
+}
+
+func (f *fakeEgressRulesClient) CountRulesReferencingSecret(_ context.Context, secretID string) (EgressSecretReferences, error) {
+	f.called = true
+	f.secretID = secretID
+	if f.err != nil {
+		return EgressSecretReferences{}, f.err
+	}
+	return f.references, nil
+}
+
+func TestResolveSecretExists(t *testing.T) {
+	secretID := uuid.New()
+	organizationID := uuid.New()
+	secret := store.Secret{ID: secretID, OrganizationID: organizationID}
+
+	resp, err := (&Server{store: &fakeSecretStore{getSecret: secret}}).ResolveSecretExists(context.Background(), &secretsv1.ResolveSecretExistsRequest{Id: secretID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.GetExists() {
+		t.Fatalf("expected secret to exist")
+	}
+	if resp.GetOrganizationId() != organizationID.String() {
+		t.Fatalf("expected organization_id %q, got %q", organizationID.String(), resp.GetOrganizationId())
+	}
+
+	resp, err = (&Server{store: &fakeSecretStore{getSecretErr: store.ErrSecretNotFound}}).ResolveSecretExists(context.Background(), &secretsv1.ResolveSecretExistsRequest{Id: secretID.String()})
+	if err != nil {
+		t.Fatalf("unexpected missing-secret error: %v", err)
+	}
+	if resp.GetExists() {
+		t.Fatalf("expected missing secret response")
+	}
+	if resp.GetOrganizationId() != "" {
+		t.Fatalf("expected empty organization_id, got %q", resp.GetOrganizationId())
+	}
+}
+
+func TestDeleteSecretEgressReferenceCheck(t *testing.T) {
+	secretID := uuid.New()
+
+	t.Run("allows unreferenced delete", func(t *testing.T) {
+		egressClient := &fakeEgressRulesClient{}
+		store := &fakeSecretStore{}
+		_, err := (&Server{store: store, egressRules: egressClient}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !egressClient.called {
+			t.Fatalf("expected egress reference check")
+		}
+		if egressClient.secretID != secretID.String() {
+			t.Fatalf("expected checked secret id %q, got %q", secretID.String(), egressClient.secretID)
+		}
+		if store.deletedSecretID != secretID {
+			t.Fatalf("expected deleted secret id %q, got %q", secretID, store.deletedSecretID)
+		}
+	})
+
+	t.Run("rejects referenced delete", func(t *testing.T) {
+		egressClient := &fakeEgressRulesClient{references: EgressSecretReferences{Count: 2, EgressRuleIDs: []string{"rule-b", "rule-a"}}}
+		store := &fakeSecretStore{}
+		_, err := (&Server{store: store, egressRules: egressClient}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		assertStatusCode(t, err, codes.FailedPrecondition)
+		if store.deletedSecretID != uuid.Nil {
+			t.Fatalf("secret should not be deleted")
+		}
+		if !strings.Contains(err.Error(), "rule-a, rule-b") {
+			t.Fatalf("expected referenced rule ids in error, got %v", err)
+		}
+	})
+
+	t.Run("fails closed without client", func(t *testing.T) {
+		store := &fakeSecretStore{}
+		_, err := (&Server{store: store}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		assertStatusCode(t, err, codes.FailedPrecondition)
+		if store.deletedSecretID != uuid.Nil {
+			t.Fatalf("secret should not be deleted")
+		}
+	})
+
+	t.Run("fails closed on check error", func(t *testing.T) {
+		egressClient := &fakeEgressRulesClient{err: errors.New("unavailable")}
+		store := &fakeSecretStore{}
+		_, err := (&Server{store: store, egressRules: egressClient}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		assertStatusCode(t, err, codes.FailedPrecondition)
+		if store.deletedSecretID != uuid.Nil {
+			t.Fatalf("secret should not be deleted")
+		}
+	})
+}
+
+func assertStatusCode(t *testing.T, err error, want codes.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected status error, got %v", err)
+	}
+	if st.Code() != want {
+		t.Fatalf("expected code %v, got %v", want, st.Code())
 	}
 }


### PR DESCRIPTION
## Summary
- Implements `ResolveSecretExists` so EgressRules can validate secret references without resolving secret values.
- Adds an EgressRules gRPC client and blocks `DeleteSecret` when `CountRulesReferencingSecret` reports active references.
- Fails closed on delete when the EgressRules reference check is unavailable or not configured.
- Adds Helm/config wiring for `EGRESS_RULES_GRPC_TARGET` and updates codegen workflows to generate egress stubs.

## Issues
- agynio/architecture#151
- agynio/secrets#17

## Test & Lint Summary
- `buf generate buf.build/agynio/api --path agynio/api/secrets/v1`: passed.
- `buf generate buf.build/agynio/api --path agynio/api/egress/v1`: passed.
- `go test -json ./...`: 31 passed, 0 failed, 0 skipped.
- `go vet ./...`: passed with no errors.
- `go build ./...`: passed.
- `helm lint charts/secrets --set database.url=dummy --set secrets.encryptionKeyFile=/etc/secrets/key`: passed with no lint failures.
