### PR TITLE
fix(chart): stabilize platform defaults

### DIFF
--- a/charts/secrets/values.yaml
+++ b/charts/secrets/values.yaml
@@ -8,7 +8,7 @@ image:
 imagePullSecrets: []
 
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride: "secrets"
 
 serviceAccount:
   create: true
@@ -40,12 +40,12 @@ database:
   url: ""
   existingSecret:
     # Secret containing the database URL. Leave empty when using `database.url`.
-    name: ""
+    name: agyn-platform-database-urls
     # Key within the secret that stores the connection string.
-    key: database-url
+    key: secrets
 
 secrets:
-  encryptionKeyFile: ""
+  encryptionKeyFile: "/etc/secrets-encryption/encryptionKey"
   encryptionKeySecretName: "secrets-encryption-key"
 
 egressRules:


### PR DESCRIPTION
## Summary
- Stabilizes chart defaults for agyn-platform production deployment.
- Moves stable fullname, database Secret, sibling service, and runtime defaults into the service chart.
- Keeps generated Chart.lock, vendored chart archives, and packaged outputs out of the commit.

Refs #4

## Validation
- `helm dependency build charts/<chart>`
- `helm lint charts/<chart>`
- `helm template test charts/<chart>`

Results: 1 chart linted, 0 failed; template render succeeded.
