### PR TITLE
fix(release): verify matching image tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,12 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
+            ${{ env.IMAGE_NAME }}:${{ env.CHART_VERSION }}
             ${{ env.IMAGE_NAME }}:latest
+
+      - name: Verify matching image tag
+        run: |
+          docker buildx imagetools inspect "${IMAGE_NAME}:${CHART_VERSION}" >/dev/null
 
   charts:
     name: Package and publish Helm chart
@@ -98,6 +103,10 @@ jobs:
 
       - name: Lint chart
         run: helm lint ${{ env.CHART_PATH }} --set database.url=dummy
+
+      - name: Verify matching image tag
+        run: |
+          docker buildx imagetools inspect "${IMAGE_NAME}:${CHART_VERSION}" >/dev/null
 
       - name: Package chart
         run: |


### PR DESCRIPTION
## Summary
- Adds release pipeline verification that `ghcr.io/agynio/secrets:<chart version>` exists before chart publication.
- Publishes both `vX.Y.Z` and matching bare `X.Y.Z` image tags for future releases.
- Confirmed and backfilled the missing `ghcr.io/agynio/secrets:0.2.1` tag from existing `v0.2.1` image content.

Fixes #20

## Validation
- `buf generate buf.build/agynio/api --path agynio/api/secrets/v1`
- `buf generate buf.build/agynio/api --path agynio/api/egress/v1`
- `go test ./...` — 3 passed, 0 failed, 0 skipped
- `helm lint charts/secrets --set database.url=dummy --set database.existingSecret.name=` — 1 chart linted, 0 failed
- `helm template secrets charts/secrets --set database.url=dummy --set database.existingSecret.name=` — rendered successfully
- `docker manifest inspect ghcr.io/agynio/secrets:0.2.1` — image tag exists
- `gofmt -w $(git ls-files '*.go')`
- `git diff --check`

## Release note
No new chart version is required for the backfilled 0.2.1 image. Pipeline guard changes will apply after merge.
