### PR TITLE
fix(release): require amd64 image support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
             echo "Tag must follow v*.*.*" >&2
             exit 1
           fi
+          if [[ ",${DOCKER_PLATFORMS}," != *",linux/amd64,"* ]]; then
+            echo "DOCKER_PLATFORMS must include linux/amd64" >&2
+            exit 1
+          fi
           echo "RELEASE_VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
           echo "CHART_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
@@ -73,7 +77,19 @@ jobs:
 
       - name: Verify matching image tag
         run: |
-          docker buildx imagetools inspect "${IMAGE_NAME}:${CHART_VERSION}" >/dev/null
+          IMAGE_REF="${IMAGE_NAME}:${CHART_VERSION}"
+          INSPECT="$(docker buildx imagetools inspect "$IMAGE_REF" --raw)"
+          if ! echo "$INSPECT" | jq -e '
+            if .manifests then
+              any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64")
+            else
+              .architecture == "amd64" and .os == "linux"
+            end
+          ' >/dev/null; then
+            echo "::error::$IMAGE_REF does not include linux/amd64"
+            exit 1
+          fi
+          echo "$IMAGE_REF includes linux/amd64"
 
   charts:
     name: Package and publish Helm chart
@@ -106,7 +122,19 @@ jobs:
 
       - name: Verify matching image tag
         run: |
-          docker buildx imagetools inspect "${IMAGE_NAME}:${CHART_VERSION}" >/dev/null
+          IMAGE_REF="${IMAGE_NAME}:${CHART_VERSION}"
+          INSPECT="$(docker buildx imagetools inspect "$IMAGE_REF" --raw)"
+          if ! echo "$INSPECT" | jq -e '
+            if .manifests then
+              any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64")
+            else
+              .architecture == "amd64" and .os == "linux"
+            end
+          ' >/dev/null; then
+            echo "::error::$IMAGE_REF does not include linux/amd64"
+            exit 1
+          fi
+          echo "$IMAGE_REF includes linux/amd64"
 
       - name: Package chart
         run: |


### PR DESCRIPTION
## Summary
- Adds release workflow validation that `DOCKER_PLATFORMS` includes `linux/amd64`.
- Strengthens release image verification to inspect the published chart-compatible image tag and fail if it lacks `linux/amd64`.
- Backfilled `ghcr.io/agynio/secrets:0.2.1` as a manifest list including `linux/amd64` and the existing `linux/arm64` image.

Closes #22

## Validation
- `buf generate buf.build/agynio/api --path agynio/api/secrets/v1`
- `buf generate buf.build/agynio/api --path agynio/api/egress/v1`
- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go vet ./...`
- `helm lint charts/secrets --set database.url=dummy`
- `helm template secrets charts/secrets --set database.existingSecret.name= --set database.url=dummy >/tmp/secrets-rendered.yaml`
- `docker manifest inspect ghcr.io/agynio/secrets:0.2.1`
- `DOCKER_BUILDKIT=1 docker build --network host --platform linux/amd64 --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64 --load -t ghcr.io/agynio/secrets:0.2.1-amd64-local .`
- `docker run --rm --platform linux/amd64 --entrypoint /usr/local/bin/secrets ghcr.io/agynio/secrets:0.2.1-amd64-local --help` reached the binary and failed on missing `DATABASE_URL`, confirming no exec format error.

## Manifest verification
`ghcr.io/agynio/secrets:0.2.1` now includes:
- `linux/arm64` digest `sha256:f13c44d4c085c20117890e4bb5d3170136b1deea0a652b3f502cb463e52f66fc`
- `linux/amd64` digest `sha256:374e95b6266ad26c252870b33a6b4265d76d0a86ae9d6adabacbe1168c62b492`

## Release note
The image backfill was required on the existing `0.2.1` tag. Workflow hardening is in this PR and will apply after merge.