### PR TITLE
Refuse deleting a secret an image names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Generate protobuf stubs
         run: |
-          buf generate buf.build/agynio/api --path agynio/api/egress/v1 --path agynio/api/secrets/v1 --path agynio/api/llm/v1
+          make proto
 
       - name: Go build
         run: go build ./...

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate protobuf stubs
         run: |
-          buf generate buf.build/agynio/api --path agynio/api/egress/v1 --path agynio/api/secrets/v1 --path agynio/api/llm/v1
+          make proto
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -88,7 +88,7 @@ jobs:
 
       - name: Generate protobuf stubs
         run: |
-          buf generate buf.build/agynio/api --path agynio/api/egress/v1 --path agynio/api/secrets/v1 --path agynio/api/llm/v1
+          make proto
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Generate protobuf stubs
         run: |
-          buf generate buf.build/agynio/api --path agynio/api/egress/v1 --path agynio/api/secrets/v1 --path agynio/api/llm/v1
+          make proto
 
       - name: Build and push secrets image
         uses: docker/build-push-action@v6

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 all: build
 
 proto:
-	buf generate buf.build/agynio/api --path agynio/api/egress/v1 --path agynio/api/secrets/v1
+	buf generate buf.build/agynio/api --path agynio/api/egress/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/images/v1
 
 build:
 	GOFLAGS=-mod=mod go build ./...

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ go run ./cmd/secrets
 | `GRPC_ADDRESS` | No | `:50051` | Address for the gRPC server to listen on. |
 | `ENCRYPTION_KEY_FILE` | Yes | - | Path to the encryption key file used for local secret values. |
 | `EGRESS_RULES_GRPC_TARGET` | No | - | EgressRules gRPC target used to fail-closed on `DeleteSecret` when egress rules reference a secret. |
+| `LLM_GRPC_TARGET` | No | - | LLM gRPC target, same purpose for subscriptions holding a secret by reference. |
+| `IMAGES_GRPC_TARGET` | No | - | Images gRPC target, same purpose for images naming a secret as their registry credential. |
 
 ## Repository Layout
 

--- a/charts/secrets/templates/deployment.yaml
+++ b/charts/secrets/templates/deployment.yaml
@@ -87,6 +87,10 @@ spec:
             - name: LLM_GRPC_TARGET
               value: {{ . | quote }}
             {{- end }}
+            {{- with .Values.images.grpcTarget }}
+            - name: IMAGES_GRPC_TARGET
+              value: {{ . | quote }}
+            {{- end }}
 {{- include "secrets.encryptionKeyEnv" . | nindent 12 }}
           livenessProbe:
             tcpSocket:

--- a/charts/secrets/values.yaml
+++ b/charts/secrets/values.yaml
@@ -56,6 +56,10 @@ egressRules:
 llm:
   grpcTarget: ""
 
+# Same for an Image naming the secret as its registry credential.
+images:
+  grpcTarget: ""
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/cmd/secrets/main.go
+++ b/cmd/secrets/main.go
@@ -75,6 +75,14 @@ func run() error {
 		defer llmConn.Close()
 	}
 	secretsServer.WithLLMClient(llmClient)
+	imagesClient, imagesConn, err := server.DialImagesClient(ctx, cfg.ImagesGRPCTarget)
+	if err != nil {
+		return err
+	}
+	if imagesConn != nil {
+		defer imagesConn.Close()
+	}
+	secretsServer.WithImagesClient(imagesClient)
 	secretsv1.RegisterSecretsServiceServer(grpcServer, secretsServer)
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	EncryptionKeyFile     string
 	EgressRulesGRPCTarget string
 	LLMGRPCTarget         string
+	ImagesGRPCTarget      string
 }
 
 func FromEnv() (Config, error) {
@@ -29,5 +30,6 @@ func FromEnv() (Config, error) {
 	}
 	cfg.EgressRulesGRPCTarget = os.Getenv("EGRESS_RULES_GRPC_TARGET")
 	cfg.LLMGRPCTarget = os.Getenv("LLM_GRPC_TARGET")
+	cfg.ImagesGRPCTarget = os.Getenv("IMAGES_GRPC_TARGET")
 	return cfg, nil
 }

--- a/internal/server/images.go
+++ b/internal/server/images.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	imagesv1 "github.com/agynio/secrets/gen/go/agynio/api/images/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// ImagesClient answers whether any Image holds this secret by reference as its
+// registry credential. Not a dependency cycle, for the same reason the LLM one
+// isn't: Secrets calls out only on delete, and the Images service calls in only
+// on image create and update.
+type ImagesClient interface {
+	CountImagesReferencingSecret(ctx context.Context, secretID string) (ImageSecretReferences, error)
+}
+
+type ImageSecretReferences struct {
+	Count    int32
+	ImageIDs []string
+}
+
+type imagesGRPCClient struct {
+	client imagesv1.ImagesServiceClient
+}
+
+func NewImagesGRPCClient(conn grpc.ClientConnInterface) ImagesClient {
+	return imagesGRPCClient{client: imagesv1.NewImagesServiceClient(conn)}
+}
+
+func DialImagesClient(ctx context.Context, target string) (ImagesClient, *grpc.ClientConn, error) {
+	trimmedTarget := strings.TrimSpace(target)
+	if trimmedTarget == "" {
+		return nil, nil, nil
+	}
+	conn, err := grpc.NewClient(trimmedTarget, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("create images grpc client: %w", err)
+	}
+	return NewImagesGRPCClient(conn), conn, nil
+}
+
+func (c imagesGRPCClient) CountImagesReferencingSecret(ctx context.Context, secretID string) (ImageSecretReferences, error) {
+	resp, err := c.client.CountImagesReferencingSecret(ctx, &imagesv1.CountImagesReferencingSecretRequest{SecretId: secretID})
+	if err != nil {
+		return ImageSecretReferences{}, err
+	}
+	return ImageSecretReferences{
+		Count:    resp.GetCount(),
+		ImageIDs: resp.GetImageIds(),
+	}, nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,7 @@ type Server struct {
 	vault         VaultResolver
 	egressRules   EgressRulesClient
 	llm           LLMClient
+	images        ImagesClient
 	encryptionKey []byte
 }
 
@@ -52,6 +53,11 @@ func New(store SecretStore, vaultClient VaultResolver, encryptionKey []byte) *Se
 
 func (s *Server) WithLLMClient(client LLMClient) *Server {
 	s.llm = client
+	return s
+}
+
+func (s *Server) WithImagesClient(client ImagesClient) *Server {
+	s.images = client
 	return s
 }
 
@@ -343,6 +349,15 @@ func (s *Server) ensureSecretUnreferenced(ctx context.Context, secretID uuid.UUI
 	} else if refs.Count > 0 {
 		sort.Strings(refs.SubscriptionIDs)
 		blockers = append(blockers, fmt.Sprintf("%d subscription(s): %s", refs.Count, strings.Join(refs.SubscriptionIDs, ", ")))
+	}
+
+	if s.images == nil {
+		unverifiable = append(unverifiable, "image")
+	} else if refs, err := s.images.CountImagesReferencingSecret(ctx, secretID.String()); err != nil {
+		unverifiable = append(unverifiable, fmt.Sprintf("image (%v)", err))
+	} else if refs.Count > 0 {
+		sort.Strings(refs.ImageIDs)
+		blockers = append(blockers, fmt.Sprintf("%d image(s): %s", refs.Count, strings.Join(refs.ImageIDs, ", ")))
 	}
 
 	if len(blockers) > 0 {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -319,6 +319,22 @@ func (f *fakeLLMClient) CountSubscriptionsReferencingSecret(_ context.Context, s
 	return f.references, nil
 }
 
+type fakeImagesClient struct {
+	references ImageSecretReferences
+	err        error
+	secretID   string
+	called     bool
+}
+
+func (f *fakeImagesClient) CountImagesReferencingSecret(_ context.Context, secretID string) (ImageSecretReferences, error) {
+	f.called = true
+	f.secretID = secretID
+	if f.err != nil {
+		return ImageSecretReferences{}, f.err
+	}
+	return f.references, nil
+}
+
 func TestResolveSecretExists(t *testing.T) {
 	secretID := uuid.New()
 	organizationID := uuid.New()
@@ -353,7 +369,7 @@ func TestDeleteSecretEgressReferenceCheck(t *testing.T) {
 	t.Run("allows unreferenced delete", func(t *testing.T) {
 		egressClient := &fakeEgressRulesClient{}
 		store := &fakeSecretStore{}
-		_, err := (&Server{store: store, egressRules: egressClient, llm: &fakeLLMClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		_, err := (&Server{store: store, egressRules: egressClient, llm: &fakeLLMClient{}, images: &fakeImagesClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -371,7 +387,7 @@ func TestDeleteSecretEgressReferenceCheck(t *testing.T) {
 	t.Run("rejects referenced delete", func(t *testing.T) {
 		egressClient := &fakeEgressRulesClient{references: EgressSecretReferences{Count: 2, EgressRuleIDs: []string{"rule-b", "rule-a"}}}
 		store := &fakeSecretStore{}
-		_, err := (&Server{store: store, egressRules: egressClient, llm: &fakeLLMClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		_, err := (&Server{store: store, egressRules: egressClient, llm: &fakeLLMClient{}, images: &fakeImagesClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
 		assertStatusCode(t, err, codes.FailedPrecondition)
 		if store.deletedSecretID != uuid.Nil {
 			t.Fatalf("secret should not be deleted")
@@ -393,7 +409,7 @@ func TestDeleteSecretEgressReferenceCheck(t *testing.T) {
 	t.Run("rejects delete referenced by a subscription", func(t *testing.T) {
 		llmClient := &fakeLLMClient{references: SubscriptionSecretReferences{Count: 1, SubscriptionIDs: []string{"sub-a"}}}
 		store := &fakeSecretStore{}
-		_, err := (&Server{store: store, egressRules: &fakeEgressRulesClient{}, llm: llmClient}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		_, err := (&Server{store: store, egressRules: &fakeEgressRulesClient{}, llm: llmClient, images: &fakeImagesClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
 		assertStatusCode(t, err, codes.FailedPrecondition)
 		if store.deletedSecretID != uuid.Nil {
 			t.Fatalf("secret should not be deleted")
@@ -403,15 +419,32 @@ func TestDeleteSecretEgressReferenceCheck(t *testing.T) {
 		}
 	})
 
-	// Both classes at once: deleting the egress rule and being refused again for
+	t.Run("rejects delete referenced by an image", func(t *testing.T) {
+		imagesClient := &fakeImagesClient{references: ImageSecretReferences{Count: 1, ImageIDs: []string{"image-a"}}}
+		store := &fakeSecretStore{}
+		_, err := (&Server{store: store, egressRules: &fakeEgressRulesClient{}, llm: &fakeLLMClient{}, images: imagesClient}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		assertStatusCode(t, err, codes.FailedPrecondition)
+		if store.deletedSecretID != uuid.Nil {
+			t.Fatalf("secret should not be deleted")
+		}
+		if imagesClient.secretID != secretID.String() {
+			t.Fatalf("expected checked secret id %q, got %q", secretID.String(), imagesClient.secretID)
+		}
+		if !strings.Contains(err.Error(), "image-a") {
+			t.Fatalf("expected the referencing image in the error, got %v", err)
+		}
+	})
+
+	// Every class at once: deleting the egress rule and being refused again for
 	// a subscription is a worse experience than one complete answer.
 	t.Run("names every class of reference at once", func(t *testing.T) {
 		egressClient := &fakeEgressRulesClient{references: EgressSecretReferences{Count: 1, EgressRuleIDs: []string{"rule-a"}}}
 		llmClient := &fakeLLMClient{references: SubscriptionSecretReferences{Count: 1, SubscriptionIDs: []string{"sub-a"}}}
-		_, err := (&Server{store: &fakeSecretStore{}, egressRules: egressClient, llm: llmClient}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		imagesClient := &fakeImagesClient{references: ImageSecretReferences{Count: 1, ImageIDs: []string{"image-a"}}}
+		_, err := (&Server{store: &fakeSecretStore{}, egressRules: egressClient, llm: llmClient, images: imagesClient}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
 		assertStatusCode(t, err, codes.FailedPrecondition)
-		if !strings.Contains(err.Error(), "rule-a") || !strings.Contains(err.Error(), "sub-a") {
-			t.Fatalf("expected both classes named, got %v", err)
+		if !strings.Contains(err.Error(), "rule-a") || !strings.Contains(err.Error(), "sub-a") || !strings.Contains(err.Error(), "image-a") {
+			t.Fatalf("expected every class named, got %v", err)
 		}
 	})
 
@@ -428,7 +461,16 @@ func TestDeleteSecretEgressReferenceCheck(t *testing.T) {
 
 	t.Run("fails closed without a subscription client", func(t *testing.T) {
 		store := &fakeSecretStore{}
-		_, err := (&Server{store: store, egressRules: &fakeEgressRulesClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		_, err := (&Server{store: store, egressRules: &fakeEgressRulesClient{}, images: &fakeImagesClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		assertStatusCode(t, err, codes.FailedPrecondition)
+		if store.deletedSecretID != uuid.Nil {
+			t.Fatalf("secret should not be deleted")
+		}
+	})
+
+	t.Run("fails closed without an images client", func(t *testing.T) {
+		store := &fakeSecretStore{}
+		_, err := (&Server{store: store, egressRules: &fakeEgressRulesClient{}, llm: &fakeLLMClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
 		assertStatusCode(t, err, codes.FailedPrecondition)
 		if store.deletedSecretID != uuid.Nil {
 			t.Fatalf("secret should not be deleted")
@@ -438,7 +480,7 @@ func TestDeleteSecretEgressReferenceCheck(t *testing.T) {
 	t.Run("fails closed on check error", func(t *testing.T) {
 		egressClient := &fakeEgressRulesClient{err: errors.New("unavailable")}
 		store := &fakeSecretStore{}
-		_, err := (&Server{store: store, egressRules: egressClient, llm: &fakeLLMClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
+		_, err := (&Server{store: store, egressRules: egressClient, llm: &fakeLLMClient{}, images: &fakeImagesClient{}}).DeleteSecret(context.Background(), &secretsv1.DeleteSecretRequest{Id: secretID.String()})
 		assertStatusCode(t, err, codes.FailedPrecondition)
 		if store.deletedSecretID != uuid.Nil {
 			t.Fatalf("secret should not be deleted")


### PR DESCRIPTION
Depends on agynio/api#190 and pairs with agynio/images#3.

An Image now holds its registry credential by reference, which puts it in the same position as an EgressRule's `inject` and a Subscription's `secret_id`: the credential it reads with can be deleted out from under it. `DeleteSecret` gains the third check.

Adds `ImagesClient` mirroring `llm.go` and `egress_rules.go`, and folds it into `ensureSecretUnreferenced` so every class of reference is still reported in one error rather than one refusal at a time.

Fails closed when `IMAGES_GRPC_TARGET` is unset, as the other two do — the umbrella wires it in agynio/platform-charts.