### PR TITLE
Default the reference-check targets to their peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ go run ./cmd/secrets
 | `DATABASE_URL` | Yes | - | PostgreSQL connection string. |
 | `GRPC_ADDRESS` | No | `:50051` | Address for the gRPC server to listen on. |
 | `ENCRYPTION_KEY_FILE` | Yes | - | Path to the encryption key file used for local secret values. |
-| `EGRESS_RULES_GRPC_TARGET` | No | - | EgressRules gRPC target used to fail-closed on `DeleteSecret` when egress rules reference a secret. |
-| `LLM_GRPC_TARGET` | No | - | LLM gRPC target, same purpose for subscriptions holding a secret by reference. |
-| `IMAGES_GRPC_TARGET` | No | - | Images gRPC target, same purpose for images naming a secret as their registry credential. |
+| `EGRESS_RULES_GRPC_TARGET` | No | `egress:50051` | EgressRules gRPC target, asked before `DeleteSecret` whether a rule references the secret. |
+| `LLM_GRPC_TARGET` | No | `llm:50051` | LLM gRPC target, same question for subscriptions holding a secret by reference. |
+| `IMAGES_GRPC_TARGET` | No | `images:50051` | Images gRPC target, same question for images naming a secret as their registry credential. |
+
+The three targets default to each peer's name in its own namespace, which is where they are. Set one only to point somewhere else.
 
 ## Repository Layout
 

--- a/charts/secrets/values.yaml
+++ b/charts/secrets/values.yaml
@@ -48,15 +48,14 @@ secrets:
   encryptionKeyFile: "/etc/secrets-encryption/encryptionKey"
   encryptionKeySecretName: "secrets-encryption-key"
 
+# Deleting a secret is refused while an EgressRule, a Subscription, or an Image
+# holds it by reference, so the service asks each of them first. It defaults to
+# each peer's name in its own namespace, which is where they are: set these only
+# to point somewhere else.
 egressRules:
   grpcTarget: ""
-
-# Secret deletion is refused when a Subscription holds the secret by reference,
-# so this must point at the LLM service or deletes fail closed.
 llm:
   grpcTarget: ""
-
-# Same for an Image naming the secret as its registry credential.
 images:
   grpcTarget: ""
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,8 +28,19 @@ func FromEnv() (Config, error) {
 	if cfg.EncryptionKeyFile == "" {
 		return Config{}, fmt.Errorf("ENCRYPTION_KEY_FILE must be set")
 	}
-	cfg.EgressRulesGRPCTarget = os.Getenv("EGRESS_RULES_GRPC_TARGET")
-	cfg.LLMGRPCTarget = os.Getenv("LLM_GRPC_TARGET")
-	cfg.ImagesGRPCTarget = os.Getenv("IMAGES_GRPC_TARGET")
+	// Every service this one asks about a secret reference is a peer in the same
+	// namespace, reachable at its own name. Defaulting means an install wires
+	// nothing: an operator sets these only to point somewhere else. Left to the
+	// caller they arrive unset, and an unset target fails DeleteSecret closed.
+	cfg.EgressRulesGRPCTarget = envOr("EGRESS_RULES_GRPC_TARGET", "egress:50051")
+	cfg.LLMGRPCTarget = envOr("LLM_GRPC_TARGET", "llm:50051")
+	cfg.ImagesGRPCTarget = envOr("IMAGES_GRPC_TARGET", "images:50051")
 	return cfg, nil
+}
+
+func envOr(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,39 @@
+package config
+
+import "testing"
+
+// The reference-check targets default to each peer's name, so an install wires
+// nothing. Left to the caller they arrive unset, and an unset target fails
+// DeleteSecret closed.
+func TestReferenceCheckTargetsDefault(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://x")
+	t.Setenv("ENCRYPTION_KEY_FILE", "/etc/key")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	for _, test := range []struct{ name, got, want string }{
+		{"egress rules", cfg.EgressRulesGRPCTarget, "egress:50051"},
+		{"llm", cfg.LLMGRPCTarget, "llm:50051"},
+		{"images", cfg.ImagesGRPCTarget, "images:50051"},
+	} {
+		if test.got != test.want {
+			t.Errorf("%s target = %q, want %q", test.name, test.got, test.want)
+		}
+	}
+}
+
+func TestReferenceCheckTargetsOverride(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://x")
+	t.Setenv("ENCRYPTION_KEY_FILE", "/etc/key")
+	t.Setenv("IMAGES_GRPC_TARGET", "images.elsewhere:50051")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ImagesGRPCTarget != "images.elsewhere:50051" {
+		t.Fatalf("images target = %q, want the override", cfg.ImagesGRPCTarget)
+	}
+}


### PR DESCRIPTION
`DeleteSecret` asks EgressRules, LLM and Images whether anything still references the secret. All three targets had to be supplied by the umbrella, and an unset one fails the delete closed — so an install had to wire three values that only ever have one sensible answer, and got a broken `DeleteSecret` if it missed one.

They now default to `egress:50051`, `llm:50051` and `images:50051` — each peer's name in its own namespace, which is where they are. The chart values remain as overrides for pointing somewhere else.

This makes agynio/platform-charts#118 unnecessary; closing it.